### PR TITLE
Script is currently cloning the wrong branch?

### DIFF
--- a/emoncms9install
+++ b/emoncms9install
@@ -85,8 +85,7 @@ sudo chown www-data:root /home/pi/data/phptimeseries
 echo "git clone emoncms repo into /var/www/"
 sudo chown pi /var/www
 cd /var/www
-git clone https://github.com/emoncms/emoncms.git
-cd /var/www/emoncms && git checkout 9.0
+git clone -b stable https://github.com/emoncms/emoncms.git
 
 echo "Use default.emonpi.settings.php as settings.php"
 cp /var/www/emoncms/default.emonpi.settings.php /var/www/emoncms/settings.php


### PR DESCRIPTION
'master' is set as the default branch in github, and which is being cloned by this script.
By specifying '-b stable' forces the script to clone the 'stable' branch instead.