### PR TITLE
fix link to emonSD pre-built SD Card image wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 - [Setup Guide](https://guide.openenergymonitor.org/)
 
-- [emonSD pre-built SD card image download](https://github.com/openenergymonitor/emonpi/wiki/emonSD-pre-built-SD-card-Repository-&-Change-Log)
+- [emonSD pre-built SD card image download](https://github.com/openenergymonitor/emonpi/wiki/emonSD-pre-built-SD-card-Download-&-Change-Log)
 
 
 ## Technical:


### PR DESCRIPTION
Nothing special, was just confused why link took me to a create wiki page so thought I'd fix it 😄 