### PR TITLE
Add "quiet mode" to the emonPi "RF" firmware

### DIFF
--- a/firmware/src/rf.ino
+++ b/firmware/src/rf.ino
@@ -16,38 +16,41 @@ void RF_Setup(){
 boolean RF_Rx_Handle(){
   
 	if (rf12_recvDone()) {						//if RF Packet is received 
-	    byte n = rf12_len;
-	    if (rf12_crc == 0)							//Check packet is good
-	    {
-	    	Serial.print(F("OK"));
-	    	Serial.print(F(" "));							//Print RF packet to serial in struct format
-	    	Serial.print(rf12_hdr & 0x1F);				// Extract and print node ID
-	    	Serial.print(F(" "));
-	    	for (byte i = 0; i < n; ++i) {
-	      		Serial.print((word)rf12_data[i]);
-	      		Serial.print(F(" "));
-	    	}
-
-	      	#if RF69_COMPAT
-		    // display RSSI value after packet data e.g (-xx)
-		    Serial.print(F("("));
-		    Serial.print(-(RF69::rssi>>1));
-		    Serial.print(F(")"));
-			#endif
-		    	Serial.println();
-
-	        if (RF12_WANTS_ACK==1) {
-	           // Serial.print(F(" -> ack"));
-	           rf12_sendStart(RF12_ACK_REPLY, 0, 0);
-	       }
-
-	    return(1);
+	    if (rf12_crc == 0) {					//Check packet is good
+	    	Serial.print(F("OK"));     //Print "good packet" line prefix
+        print_frame(rf12_len);      //Print recieved data
+        if (RF12_WANTS_ACK==1) {
+             // Serial.print(F(" -> ack"));
+             rf12_sendStart(RF12_ACK_REPLY, 0, 0);
+        }
+        return(1);
+	    } else {
+	      if (quiet_mode == 0) {          //if the packet is bad
+	        Serial.print(F(" ?"));    //Print the "bad packet" line prefix
+          print_frame(20);          //Print only the first 20 bytes of a bad packet
+        }
+	      return(0);
 	    }
-	    else
-			return(0);
 	       
 	} //end recDone
 	
+}
+
+void print_frame (int len) {
+    Serial.print(F(" "));
+    Serial.print(rf12_hdr & 0x1F);        // Extract and print node ID
+    Serial.print(F(" "));
+    for (byte i = 0; i < len; ++i) {
+        Serial.print((word)rf12_data[i]);
+        Serial.print(F(" "));
+    }
+    #if RF69_COMPAT
+    // display RSSI value after packet data e.g (-xx)
+    Serial.print(F("("));
+    Serial.print(-(RF69::rssi>>1));
+    Serial.print(F(")"));
+    #endif
+    Serial.println();
 }
 
 void send_RF(){
@@ -113,6 +116,10 @@ static void handleInput (char c) {
         }
         break;
 
+      case 'q': // turn quiet mode on or off (don't report bad packets)
+        quiet_mode = value;
+        break;
+
       case 'v': // print firmware version
         Serial.print(F("[emonPi.")); Serial.print(firmware_version*0.1); Serial.print(F("]"));
         break;
@@ -140,7 +147,9 @@ static void handleInput (char c) {
       Serial.print(RF_freq == RF12_433MHZ ? 433 :
                    RF_freq == RF12_868MHZ ? 868 :
                    RF_freq == RF12_915MHZ ? 915 : 0);
-      Serial.print(F(" MHz")); 
+      Serial.print(F(" MHz"));
+      Serial.print(F(" q")); 
+      Serial.print(quiet_mode);
     }
     Serial.print(F(" USA ")); Serial.print(USA);
     Serial.println(F(" "));

--- a/firmware/src/rf.ino
+++ b/firmware/src/rf.ino
@@ -15,25 +15,25 @@ void RF_Setup(){
 
 boolean RF_Rx_Handle(){
   
-	if (rf12_recvDone()) {						//if RF Packet is received 
-	    if (rf12_crc == 0) {					//Check packet is good
-	    	Serial.print(F("OK"));     //Print "good packet" line prefix
-        print_frame(rf12_len);      //Print recieved data
-        if (RF12_WANTS_ACK==1) {
-             // Serial.print(F(" -> ack"));
-             rf12_sendStart(RF12_ACK_REPLY, 0, 0);
-        }
-        return(1);
-	    } else {
-	      if (quiet_mode == 0) {          //if the packet is bad
-	        Serial.print(F(" ?"));    //Print the "bad packet" line prefix
-          print_frame(20);          //Print only the first 20 bytes of a bad packet
-        }
-	      return(0);
-	    }
+  if (rf12_recvDone()) {		//if RF Packet is received 
+    if (rf12_crc == 0) {		//Check packet is good
+      Serial.print(F("OK"));		//Print "good packet" line prefix
+      print_frame(rf12_len);		//Print recieved data
+      if (RF12_WANTS_ACK==1) {
+        // Serial.print(F(" -> ack"));
+        rf12_sendStart(RF12_ACK_REPLY, 0, 0);
+      }
+      return(1);
+    } else {
+      if (quiet_mode == 0) {            //if the packet is bad
+        Serial.print(F(" ?"));    	//Print the "bad packet" line prefix
+        print_frame(20);          	//Print only the first 20 bytes of a bad packet
+      }
+      return(0);
+    }
 	       
-	} //end recDone
-	
+  } //end recDone
+
 }
 
 void print_frame (int len) {

--- a/firmware/src/src.ino
+++ b/firmware/src/src.ino
@@ -151,6 +151,7 @@ static byte stack[RF12_MAXDATA+4], top, sendLen, dest;           // RF variables
 static char cmd;
 static word value;                                               // Used to store serial input
 long unsigned int start_press=0;                                 // Record time emonPi shutdown push switch is pressed
+boolean quiet_mode = 1;
 
 const char helpText1[] PROGMEM =                                 // Available Serial Commands
 "\n"
@@ -163,6 +164,7 @@ const char helpText1[] PROGMEM =                                 // Available Se
 "  ...,<nn> s - send data packet to node <nn>, no ack\n"
 "  ...,<n> p  - Set AC Adapter Vcal 1p = UK, 2p = USA\n"
 "  v          - Show firmware version\n"
+"  <n> q      - set quiet mode (1 = don't report bad packets)\n"
 ;
 
 //-------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Reintroduces the "quiet mode" seen in the rfm2pi firmwares to allow
debugging of RF issues.

Via serial "1q" sets quiet mode (default) and "0q" removes quiet mode
for a more verbose output including bad packets that have failed crc
checks. In emonHub it can be set with "quiet = true" or "quiet = false"
in the interfacer settings.