### PR TITLE
Correction to versions

### DIFF
--- a/service-runner-update.sh
+++ b/service-runner-update.sh
@@ -25,7 +25,7 @@ image_version=$(ls /boot | grep emonSD)
 echo "emonSD version: $image_version"
 echo
 
-if [ "$image_version" == "emonSD-07Nov16" ] || [ "$image_version" == "emonSD-03May16" ] || [ "$image_version" == "emonSD-13Jun18" ] || [ "$image_version" == "emonSD-18Oct18" ]; then
+if [ "$image_version" == "emonSD-07Nov16" ] || [ "$image_version" == "emonSD-03May16" ] || [ "$image_version" == "emonSD-26Oct17" ] || [ "$image_version" == "emonSD-13Jun18" ] || [ "$image_version" == "emonSD-18Oct18" ]; then
   echo "emonSD base image check passed...continue update"
 else
   echo "ERROR: emonSD base image old or undefined...update will not continue"


### PR DESCRIPTION
Commit https://github.com/openenergymonitor/emonpi/commit/ef63fd52edb5e96ba0189d938df953c583cd612d broke support for the current latest image "emonSD-26Oct17".

See https://community.openenergymonitor.org/t/after-update-to-9-9-0-process-list-all-unavaiblable/8893/7?u=pb66