### PR TITLE
Reduce PI CPU usage by approx 40%, configuration file for emonPiLCD.py & power readings displayed on lcd user configurable

### DIFF
--- a/lcd/emonPiLCD.cfg
+++ b/lcd/emonPiLCD.cfg
@@ -4,8 +4,8 @@ mqtt_passwd = emonpimqtt2016
 mqtt_host = 127.0.0.1
 mqtt_port = 1883
 mqtt_emonpi_topic = emonhub/rx/5/values
-mqtt_utilityKw_topic = emon/socomec/Kw
-mqtt_pvW_topic = emon/samilpower/PAC
+mqtt_utilityW_topic = emon/emonpi/power1
+mqtt_pvW_topic = emon/emonpi/power2
 
 [general]
 uselogfile = True

--- a/lcd/emonPiLCD.cfg
+++ b/lcd/emonPiLCD.cfg
@@ -1,0 +1,25 @@
+[mqtt]
+mqtt_user = emonpi
+mqtt_passwd = emonpimqtt2016
+mqtt_host = 127.0.0.1
+mqtt_port = 1883
+mqtt_emonpi_topic = emonhub/rx/5/values
+mqtt_utilityKw_topic = emon/socomec/Kw
+mqtt_pvW_topic = emon/samilpower/PAC
+
+[general]
+uselogfile = True
+# LCD backlight timeout in seconds 0: always on, 300: off after 5 min
+# as the emonpi could be installed in a dark place, keep the backlight on, eh ?
+backlight_timeout = 0
+# which page to show after startup (2 is pv/utility readings which should be useful)
+default_page = 2
+
+
+[redis]
+redis_host = localhost
+redis_port = 6379
+
+[huawei]
+hilink_device_ip = 192.168.1.1
+

--- a/lcd/emonPiLCD.cfg
+++ b/lcd/emonPiLCD.cfg
@@ -1,19 +1,30 @@
+[general]
+uselogfile = True
+
+# LCD backlight timeout in seconds 0: always on, 300: off after 5 min
+# as the emonpi could be installed in a dark place, keep the backlight on, eh ?
+backlight_timeout = 0
+
+#How often the LCD is updated when a button is not pressed
+lcd_update_sec = 30 
+
+# which page to show after startup (3 is pv/utility readings which should be useful)
+default_page = 3
+ 
+#Names for the power feeds displayed on the LCD
+feed1_name = Power1
+feed2_name = Power2
+feed1_unit = W
+feed2_unit = W
+
 [mqtt]
 mqtt_user = emonpi
 mqtt_passwd = emonpimqtt2016
 mqtt_host = 127.0.0.1
 mqtt_port = 1883
 mqtt_emonpi_topic = emonhub/rx/5/values
-mqtt_utilityW_topic = emon/emonpi/power1
-mqtt_pvW_topic = emon/emonpi/power2
-
-[general]
-uselogfile = True
-# LCD backlight timeout in seconds 0: always on, 300: off after 5 min
-# as the emonpi could be installed in a dark place, keep the backlight on, eh ?
-backlight_timeout = 0
-# which page to show after startup (2 is pv/utility readings which should be useful)
-default_page = 2
+mqtt_feed1_topic = emon/emonpi/power1
+mqtt_feed2_topic = emon/emonpi/power2
 
 
 [redis]

--- a/lcd/emonPiLCD.py
+++ b/lcd/emonPiLCD.py
@@ -303,6 +303,9 @@ class IPAddress(object):
         except Exception:
             return 0
 
+def preShutdown():
+    lcd[0] = "Shutdown?"
+    lcd[1] = "Hold 5 secs"
 
 def shutdown():
 
@@ -436,6 +439,7 @@ def main():
     logger.info("Attaching shutdown button interrupt...")
     try:
        shut_btn = Button(17, pull_up=False, hold_time=5)
+       shut_btn.when_pressed = preShutdown
        shut_btn.when_held = shutdown 
     except: 
        logger.error("Failed to attach shutdown button interrupt...")

--- a/lcd/emonPiLCD.py
+++ b/lcd/emonPiLCD.py
@@ -97,16 +97,40 @@ shutConfirm = False
 uselogfile =  config.get('general','uselogfile') 
 logger = logging.getLogger("emonPiLCD")
 
+#ssh enable/disable/check commands
+ssh_enable = "systemctl enable sshd > /dev/null"
+ssh_start = "systemctl start sshd > /dev/null"
+ssh_disable = "systemctl disable sshd > /dev/null"
+ssh_stop = "systemctl stop sshd > /dev/null"
+ssh_status = "systemctl status sshd > /dev/null"
+
+
+
+
 
 def buttonPressLong():
 
    logger.info("Mode button LONG press")
 
    if sshConfirm:
-      subprocess.call("/home/pi/emonpi/lcd/enablessh.sh")
-      logger.info("SSH Enabled")
-      lcd[0] = 'SSH Enabled      '
-      lcd[1] = 'Change password!'
+
+      ret=subprocess.call(ssh_status, shell=True)
+      if ret > 0 :
+         #ssh not running, enable & start it
+         subprocess.call(ssh_enable, shell=True)
+         subprocess.call(ssh_start, shell=True)
+         logger.info("SSH Enabled")
+         lcd[0] = 'SSH Enabled      '
+         lcd[1] = 'Change password!'
+      else:
+         #disable ssh
+         subprocess.call(ssh_disable, shell=True)
+         subprocess.call(ssh_stop, shell=True)
+         logger.info("SSH Disabled")
+         lcd[0] = 'SSH Disabled      '
+         lcd[1] = '                '
+         
+
    elif shutConfirm:
       logger.info("Shutting down")
       shutdown()
@@ -228,13 +252,13 @@ def updateLCD() :
         if r.get("feed1") is not None:
             lcd[0] = feed1_name + ':'  + r.get("feed1") + feed1_unit 
         else:
-            lcd[0] = feed1_name + ':'  + "No data yet"
+            lcd[0] = feed1_name + ':'  + "No data"
  
 
         if r.get("feed2") is not None:
             lcd[1] = feed2_name + ':'  + r.get("feed2") + feed2_unit 
         else:
-            lcd[1] = feed2_name + ':'  + "No data yet"
+            lcd[1] = feed2_name + ':'  + "No data"
 
    elif page == 4:
         basedata = r.get("basedata")
@@ -272,11 +296,18 @@ def updateLCD() :
         lcd[1] = sd_image_version
 
    elif page == 8:
-        lcd[0] = "SSH enable?"
+        ret=subprocess.call(ssh_status, shell=True)
+        if ret > 0 : 
+          #ssh not running
+          lcd[0] = "SSH Enable?"
+        else:
+          #ssh not running
+          lcd[0] = "SSH Disable?"
+
         lcd[1] = "Y press & hold"
 	sshConfirm = False
+
    elif page == 9:
-        lcd[0] = "SSH enable?"
         sshConfirm = True
 
    elif page == 10:

--- a/lcd/emonPiLCD.py
+++ b/lcd/emonPiLCD.py
@@ -334,6 +334,12 @@ class LCD(object):
 def main():
     global page
     global sd_image_version
+    global r
+
+    # Initialise some redis variables
+    r.set("gsm:active", 0)
+    r.set("wlan:active", 0)
+    r.set("eth:active", 0)
 
     # First set up logging
     atexit.register(logging.shutdown)

--- a/lcd/emonPiLCD.py
+++ b/lcd/emonPiLCD.py
@@ -44,7 +44,7 @@ mqtt_passwd = config.get('mqtt','mqtt_passwd')
 mqtt_host = config.get('mqtt','mqtt_host')
 mqtt_port = config.getint('mqtt','mqtt_port')
 mqtt_emonpi_topic = config.get('mqtt','mqtt_emonpi_topic') 
-mqtt_utilityKw_topic = config.get('mqtt','mqtt_utilityKw_topic')
+mqtt_utilityW_topic = config.get('mqtt','mqtt_utilityW_topic')
 mqtt_pvW_topic = config.get('mqtt','mqtt_pvW_topic')
 
 
@@ -256,8 +256,8 @@ def main():
     def on_message(client, userdata, msg):
         topic_parts = msg.topic.split("/")
 
-	if mqtt_utilityKw_topic in msg.topic: 
-	    r.set("utilitykw" , msg.payload)
+	if mqtt_utilityW_topic in msg.topic: 
+	    r.set("utilityw" , msg.payload)
 
         if mqtt_pvW_topic in msg.topic:
             r.set("pvw" , msg.payload)
@@ -269,7 +269,7 @@ def main():
         if (rc==0):
 	    logger.info(mqtt_emonpi_topic) 
             mqttc.subscribe(mqtt_emonpi_topic)
-            mqttc.subscribe(mqtt_utilityKw_topic)
+            mqttc.subscribe(mqtt_utilityW_topic)
             mqttc.subscribe(mqtt_pvW_topic)
 
     mqttc = mqtt.Client()
@@ -415,8 +415,8 @@ def main():
 
         if page == 3:
 	
-            if r.get("utilitykw") is not None:
-                lcd[0] = 'Utility: ' + r.get("utilitykw") + "KW"
+            if r.get("utilityw") is not None:
+                lcd[0] = 'Utility: ' + r.get("utilityw") + "W"
             else:
                 lcd[0] = "Utility:No data yet"
 

--- a/lcd/emonPiLCD.py
+++ b/lcd/emonPiLCD.py
@@ -83,10 +83,13 @@ current_lcd_i2c = ''
 # ------------------------------------------------------------------------------------
 
 # Default Startup Page
-max_number_pages = 7
+max_number_pages = 11
 page = default_page
 
 sd_image_version = ''
+
+sshConfirm = False 
+shutConfirm = False
 
 # ------------------------------------------------------------------------------------
 # Start Logging
@@ -96,11 +99,19 @@ logger = logging.getLogger("emonPiLCD")
 
 
 def buttonPressLong():
+
    logger.info("Mode button LONG press")
-   subprocess.call("/home/pi/emonpi/lcd/enablessh.sh")
-   logger.info("SSH Enabled")
-   lcd[0] = 'SSH Enabled      '
-   lcd[1] = 'Change password!'
+
+   if sshConfirm:
+      subprocess.call("/home/pi/emonpi/lcd/enablessh.sh")
+      logger.info("SSH Enabled")
+      lcd[0] = 'SSH Enabled      '
+      lcd[1] = 'Change password!'
+   elif shutConfirm:
+      logger.info("Shutting down")
+      shutdown()
+   else:
+      lcd.backlight = not lcd.backlight
 
 
 def buttonPress():
@@ -129,9 +140,17 @@ def updateLCD() :
    global lcd
    global r
    global logger
+   global sshConfirm
+   global shutConfirm
 
    # Create object for getting IP addresses of interfaces
    ipaddress = IPAddress()
+
+   if not page == 9:
+       sshConfirm = False
+   if not page == 11:
+       shutConfirm = False
+
 
    # Now display the appropriate LCD page
    if page == 0:
@@ -251,6 +270,22 @@ def updateLCD() :
    elif page == 7:
         lcd[0] = "emonPi Build:"
         lcd[1] = sd_image_version
+
+   elif page == 8:
+        lcd[0] = "SSH enable?"
+        lcd[1] = "Y press & hold"
+	sshConfirm = False
+   elif page == 9:
+        lcd[0] = "SSH enable?"
+        sshConfirm = True
+
+   elif page == 10:
+        lcd[0] = "Shutdown?"
+        lcd[1] = "Y press & hold"
+	shutConfirm = False
+   elif page == 11:
+        lcd[0] = "Shutdown?"
+	shutConfirm = True
 
 
 


### PR DESCRIPTION
Added config file & parser to emonPiLCD.py

Allows user to tweak config and choose other values for display for the
power readings (for example, if an external power meter is being used)

Fixed issue with backlight=0 , and default page is now the power
readings, with backlight on. Useful if emonpi is in a dark cupboard (as they usually are)

Of course, with a config file the user can easily choose their preferred settings and sane defaults can be added.