### PR TITLE
Revise mariadb ProtectHome fix

### DIFF
--- a/install/mysql.sh
+++ b/install/mysql.sh
@@ -15,12 +15,3 @@ sudo mysql -e "CREATE DATABASE $mysql_database DEFAULT CHARACTER SET utf8;"
 # Add emoncms database, set user permissions
 echo "- Add user:$mysql_user and assign to database:$mysql_database"
 sudo mysql -e "CREATE USER '$mysql_user'@'localhost' IDENTIFIED BY '$mysql_password'; GRANT ALL ON $mysql_database.* TO '$mysql_user'@'localhost'; flush privileges;"
-
-# Allow MYSQL db to be located in home folder /home/pi/data
-echo "Edit mariadb service file to allow db to be located in ~/data"
-sudo mkdir -p /etc/systemd/system/mariadb.service.d
-sudo cp /home/pi/emonpi/stretch/mariadb-service-d-override.conf /etc/systemd/system/mariadb.service.d/override.conf
-
-echo "Reload mariadb service"
-sudo systemctl daemon-reload
-sudo systemctl restart mariadb

--- a/stretch/mariadb-service-d-override.conf
+++ b/stretch/mariadb-service-d-override.conf
@@ -1,4 +1,0 @@
-# copy to /etc/systemd/system/mariadb.service.d/override.conf
-
-[Service]
-ProtectHome=false

--- a/update/emoncms.sh
+++ b/update/emoncms.sh
@@ -268,7 +268,7 @@ done
 echo "------------------------------------------"
 
 # Configure mariadb to allow db in home folder /home/pi/data
-if [ ! -f /etc/systemd/system/mariadb.service.d/override.conf ]; then
+if [ ! -f /etc/systemd/system/mariadb.service.d/override.conf ] && [ -d /home/pi/data/mysql/mysql/ ]; then
   echo "Installing mariadb service config"
   sudo mkdir -p /etc/systemd/system/mariadb.service.d/
   printf "[Service]\nProtectHome=false\n" | sudo tee /etc/systemd/system/mariadb.service.d/override.conf

--- a/update/emoncms.sh
+++ b/update/emoncms.sh
@@ -271,7 +271,7 @@ echo "------------------------------------------"
 if [ ! -f /etc/systemd/system/mariadb.service.d/override.conf ]; then
   echo "Installing mariadb service config"
   sudo mkdir -p /etc/systemd/system/mariadb.service.d/
-  sudo cp /home/pi/emonpi/stretch/mariadb-service-d-override.conf /etc/systemd/system/mariadb.service.d/override.conf
+  printf "[Service]\nProtectHome=false\n" | sudo tee /etc/systemd/system/mariadb.service.d/override.conf
 fi
 
 if [ -d /lib/systemd/system ]; then


### PR DESCRIPTION
Removed "fix" from install script as not required.
Changed update to write file rather than cp so that there is no need for a copy of the file in the repo (as not needed down the line). Removed repo copy of redundant file.