### PR TITLE
Better improve the test for mysql location

### DIFF
--- a/update/emoncms.sh
+++ b/update/emoncms.sh
@@ -268,7 +268,7 @@ done
 echo "------------------------------------------"
 
 # Configure mariadb to allow db in home folder /home/pi/data
-if [ ! -f /etc/systemd/system/mariadb.service.d/override.conf ] && [ -d /home/pi/data/mysql/mysql/ ]; then
+if [ ! -f /etc/systemd/system/mariadb.service.d/override.conf ] && grep -q "/home/pi/data/mysql" "/etc/mysql/my.cnf"; then
   echo "Installing mariadb service config"
   sudo mkdir -p /etc/systemd/system/mariadb.service.d/
   printf "[Service]\nProtectHome=false\n" | sudo tee /etc/systemd/system/mariadb.service.d/override.conf


### PR DESCRIPTION
This improves the test for the mysql location, this is needed because the fact there is a folder in data, doesn't mean it is being used. Only a test on the config path can define that.