### PR TITLE
temp hold on changing the emonhub service

### DIFF
--- a/update/emonhub.sh
+++ b/update/emonhub.sh
@@ -14,9 +14,10 @@ if [ -d $usrdir/emonhub ]; then
     git status
     git pull
 
-    service="emonhub"
-    servicepath="$usrdir/emonhub/service/emonhub.service"
-    $usrdir/emonpi/update/install_emoncms_service.sh $servicepath $service
+    # PUT ON HOLD
+    #service="emonhub"
+    #servicepath="$usrdir/emonhub/service/emonhub.service"
+    #$usrdir/emonpi/update/install_emoncms_service.sh $servicepath $service
 
     echo
     echo "Running emonhub automatic node addition script"


### PR DESCRIPTION
This will stop further users falling into the issue of /var/log filling up due to emonhub logging to both syslog and daemon.log whilst we debate the best solution.


