### PR TITLE
Save wificheck.log to tmpfs-backed /var/log

### DIFF
--- a/sudo_crontab
+++ b/sudo_crontab
@@ -24,7 +24,7 @@
 MAILTO=""
 
 # Check wifi is connecrted very 5 min
- */5 * * * * /usr/local/bin/wifi-check > /home/pi/data/wificheck.log 2>&1
+*/5 * * * * /usr/local/bin/wifi-check > /var/log/wificheck.log 2>&1
 
 # Force NTP update every 1 hour 
 


### PR DESCRIPTION
I have a emonpi which is used for forwarding all data from emonTX/emonTH to my server hosting Emoncms. It itself doesn't save any incoming data.

Few days earlier I login to it and discovered that /home/pi/data is still being written, and the only file with recent mtime is wificheck.log.

Given that wifi-check is only used for restarting wifi connection I think saving its log to /var/log would be OK, and this can prolong the life of SD card.