### PR TITLE
Fix TypeError with python >= 2.x

### DIFF
--- a/md5sum.py
+++ b/md5sum.py
@@ -14,7 +14,7 @@ def main():
             # read contents of the file
             data = file_to_check.read()
             # pipe contents of the file through
-            md5_returned = hashlib.md5(data).hexdigest()
+            md5_returned = hashlib.md5(data.encode('utf-8')).hexdigest()
     else:
         md5_returned = 0
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/pi/emonpi/md5sum.py", line 20, in <module>
    md5_returned = hashlib.md5(data).hexdigest()
TypeError: Unicode-objects must be encoded before hashing