### PR TITLE
permits to uselogfile to be a real boolean

### DIFF
--- a/lcd/emonPiLCD.py
+++ b/lcd/emonPiLCD.py
@@ -99,7 +99,7 @@ shutConfirm = False
 # ------------------------------------------------------------------------------------
 # Start Logging
 # ------------------------------------------------------------------------------------
-uselogfile = config.get('general', 'uselogfile')
+uselogfile = config.getboolean('general', 'uselogfile')
 logger = logging.getLogger("emonPiLCD")
 
 #ssh enable/disable/check commands


### PR DESCRIPTION
uselogfile is always True if using config.get()
the solution is to use config.getboolean()

The current solution does not work. It always need a logfile. If you specify uselogfile = false , it uses the logfile, and crashes if not logfile is present