### PR TITLE
emonPiLCD1.py  fix for CM firmware

### DIFF
--- a/lcd/emonPiLCD.cfg
+++ b/lcd/emonPiLCD.cfg
@@ -22,11 +22,12 @@ mqtt_user = emonpi
 mqtt_passwd = emonpimqtt2016
 mqtt_host = 127.0.0.1
 mqtt_port = 1883
-mqtt_emonpi_topic = emonhub/rx/5/values
 mqtt_temp1_topic = emon/emonpi/t1
 mqtt_temp2_topic = emon/emonpi/t2
 mqtt_vrms_topic = emon/emonpi/vrms
 mqtt_pulse_topic = emon/emonpi/pulsecount
+#comment above and uncomment below for CM based firmware
+#mqtt_pulse_topic = emon/emonpi/pulse1count
 mqtt_feed1_topic = emon/emonpi/power1
 mqtt_feed2_topic = emon/emonpi/power2
 

--- a/lcd/emonPiLCD1.py
+++ b/lcd/emonPiLCD1.py
@@ -40,7 +40,7 @@ mqtt_user = config.get('mqtt', 'mqtt_user')
 mqtt_passwd = config.get('mqtt', 'mqtt_passwd')
 mqtt_host = config.get('mqtt', 'mqtt_host')
 mqtt_port = config.getint('mqtt', 'mqtt_port')
-mqtt_topics = {config.get('mqtt', 'mqtt_emonpi_topic'): 'basedata',
+mqtt_topics = {
                config.get('mqtt', 'mqtt_temp1_topic'): 'temp1',
                config.get('mqtt', 'mqtt_temp2_topic'): 'temp2',
                config.get('mqtt', 'mqtt_feed1_topic'): 'feed1',
@@ -252,36 +252,45 @@ def updateLCD():
             lcd[1] = feed2_name + ':'  + "---"
 
     elif page == 4:
-        basedata = r.get("basedata")
-        vrms = r.get("vrms")
-        pulse = r.get("pulse")
-        if basedata is not None:
-            basedata = basedata.split(",")
-            lcd[0] = 'VRMS: ' + basedata[3] + "V"
-            lcd[1] = 'Pulse: ' + basedata[10] + "p"
-        elif vrms is not None and pulse is not None:
-            lcd[0] = 'VRMS: ' + vrms + 'V'
+        try:
+            vrmsf = float (r.get('vrms'))
+            vrmstext = "{vrms:.2f}V"
+            vrmstext = vrmstext.format(vrms = vrmsf)
+            pulse = r.get("pulse")
+
+            lcd[0] = 'VRMS: ' + vrmstext 
             lcd[1] = 'Pulse: ' + pulse + 'p'
-        else:
-            lcd[0] = 'Connecting...'
-            lcd[1] = 'Please Wait'
-            page += 1
+
+        except:
+            lcd[0] = 'VRMS: ' + "N/A"
+            lcd[1] = 'Pulse : ' + "N/A" 
+            logger.error("Error retreiving vrms/pulse or parsing to float .2f")
+            page +=1
 
     elif page == 5:
-        basedata = r.get("basedata")
-        temp1 = r.get('temp1')
-        temp2 = r.get('temp2')
-        if basedata is not None:
-            basedata = basedata.split(",")
-            lcd[0] = 'Temp 1: ' + basedata[4] + "\0C"
-            lcd[1] = 'Temp 2: ' + basedata[5] + "\0C"
-        elif temp1 is not None and temp2 is not None:
-            lcd[0] = 'Temp 1: ' + temp1 + '\0C'
-            lcd[1] = 'Temp 2: ' + temp2 + '\0C'
-        else:
-            lcd[0] = 'Connecting...'
-            lcd[1] = 'Please Wait'
-            page += 1
+        try:
+            temp1f = float (r.get('temp1'))
+            temp2f = float (r.get('temp2'))
+            temptext = "{temp:.2f}\0C"
+
+            if ( temp1f == 300  ) : 
+                text1 = "N/A" 
+            else:
+                text1 = temptext.format(temp = temp1f)
+
+            if ( temp2f == 300  ) : 
+                text2 = "N/A" 
+            else:
+                text2 = temptext.format(temp = temp2f)
+            
+            lcd[0] = 'Temp 1: ' + text1
+            lcd[1] = 'Temp 2: ' + text2 
+
+        except:
+            lcd[0] = 'Temp 1: ' + "N/A"
+            lcd[1] = 'Temp 2: ' + "N/A" 
+            logger.error("Error retreiving temperatures or parsing to float .2f")
+            page +=1
 
     elif page == 6:
     # Get uptime


### PR DESCRIPTION
Fix MQTT topic handling in config file (vrms pulse,temperature1 temperature2) and remove older unneeded basetopic config item (this matches how emonPiLCD2 works). 
Format temp and vrms to .2f
Allow emonPiLCD1.py to work with both emonlibCM and DS firmware

Unfortunately due to my bad git branching, this PR includes fixes to emonCM firmware as discussed here:

https://community.openenergymonitor.org/t/emonsd-feb24-ttyama0-used-by-kernel-causing-interference-with-rfm-emonhub/26108/4
